### PR TITLE
Sync Main from Develop

### DIFF
--- a/src/ConfigurazioniSvc/ConfigurazioniSvc.Shared/ConfigurazioniSvc.Shared.csproj
+++ b/src/ConfigurazioniSvc/ConfigurazioniSvc.Shared/ConfigurazioniSvc.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GSWCloudApp.Common" Version="1.0.29" />
+    <PackageReference Include="GSWCloudApp.Common" Version="1.0.30" />
   </ItemGroup>
 
 </Project>

--- a/src/ConfigurazioniSvc/ConfigurazioniSvc/Endpoints/ConfigurazioniEndpoints.cs
+++ b/src/ConfigurazioniSvc/ConfigurazioniSvc/Endpoints/ConfigurazioniEndpoints.cs
@@ -2,7 +2,7 @@
 using ConfigurazioniSvc.Shared.DTO;
 using GSWCloudApp.Common.Constants;
 using GSWCloudApp.Common.Routing;
-using GSWCloudApp.Common.Service;
+using GSWCloudApp.Common.Services;
 using GSWCloudApp.Common.Validation;
 using Microsoft.OpenApi.Models;
 
@@ -91,7 +91,7 @@ public class ConfigurazioniEndpoints : IEndpointRouteHandlerBuilder
                 return opt;
             });
 
-        apiGroup.MapGet(MinimalAPI.PatternFilterById, apiService.FilterAsync<Configurazione, ConfigurazioneDto>)
+        apiGroup.MapGet(MinimalAPI.PatternFilterById, apiService.FilterByIdFestaAsync<Configurazione, ConfigurazioneDto>)
             .Produces<ConfigurazioneDto>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)

--- a/src/ConfigurazioniSvc/ConfigurazioniSvc/Program.cs
+++ b/src/ConfigurazioniSvc/ConfigurazioniSvc/Program.cs
@@ -39,7 +39,7 @@ public class Program
         builder.Services.ConfigureProblemDetails();
         builder.Services.ConfigureRedisCache(builder.Configuration, redisConnection);
 
-        builder.Services.ConfigureServices<AppDbContext, MappingProfile, CreateConfigurazioneValidator>();
+        builder.Services.ConfigureServices<MappingProfile, CreateConfigurazioneValidator>();
         builder.Services.ConfigureOptions(builder.Configuration);
 
         var app = builder.Build();

--- a/src/GSWCloudApp.Common/GSWCloudApp.Common.csproj
+++ b/src/GSWCloudApp.Common/GSWCloudApp.Common.csproj
@@ -28,9 +28,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.0.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.22" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.1.0" />
     <PackageReference Include="VaultSharp" Version="1.17.5.1" />
   </ItemGroup>
 

--- a/src/GatewaySvc/GatewaySvc/GatewaySvc.csproj
+++ b/src/GatewaySvc/GatewaySvc/GatewaySvc.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ocelot" Version="23.4.0" />
+    <PackageReference Include="Ocelot" Version="23.4.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes various updates to package references and some refactoring in the `ConfigurazioniSvc` service. The most important changes include updating package versions, modifying endpoint mapping, and refactoring service configuration.

### Package Updates:
* [`src/ConfigurazioniSvc/ConfigurazioniSvc.Shared/ConfigurazioniSvc.Shared.csproj`](diffhunk://#diff-2c8d55b3bd1ea2ebcca561c21fc0e4d94b175a960653dc7caf4a7664a723de07L10-R10): Updated `GSWCloudApp.Common` package version from `1.0.29` to `1.0.30`.
* [`src/GSWCloudApp.Common/GSWCloudApp.Common.csproj`](diffhunk://#diff-8f41eef4719e17354d76d34664aa2a1190b4f1fa151ce19b4bf9c68f3ee24d04L31-R33): Updated `StackExchange.Redis` from `2.8.16` to `2.8.22`, `Swashbuckle.AspNetCore` from `7.0.0` to `7.1.0`, and `Swashbuckle.AspNetCore.Annotations` from `7.0.0` to `7.1.0`.
* [`src/GatewaySvc/GatewaySvc/GatewaySvc.csproj`](diffhunk://#diff-d59b038d30bd30dfb37c14bb439d4c47e74e35a6fbfb7bdfa0a022eadecc6467L10-R10): Updated `Ocelot` package version from `23.4.0` to `23.4.2`.

### Refactoring:
* [`src/ConfigurazioniSvc/ConfigurazioniSvc/Endpoints/ConfigurazioniEndpoints.cs`](diffhunk://#diff-d35ebd5ceeb6192e9a2852a89841fb34fd188cfc38069fd6c87120f5f202c12fL5-R5): Changed the import from `GSWCloudApp.Common.Service` to `GSWCloudApp.Common.Services` and modified the endpoint mapping method from `FilterAsync` to `FilterByIdFestaAsync`. [[1]](diffhunk://#diff-d35ebd5ceeb6192e9a2852a89841fb34fd188cfc38069fd6c87120f5f202c12fL5-R5) [[2]](diffhunk://#diff-d35ebd5ceeb6192e9a2852a89841fb34fd188cfc38069fd6c87120f5f202c12fL94-R94)
* [`src/ConfigurazioniSvc/ConfigurazioniSvc/Program.cs`](diffhunk://#diff-b493494a8dbbe2d1712ce76f22113ad0bc3edeacb8b7f4544440d128428109a9L42-R42): Refactored service configuration by removing `AppDbContext` from the `ConfigureServices` method call.