### PR TITLE
Sync Main from Develop

### DIFF
--- a/src/AutenticazioneSvc/AutenticazioneSvc.BusinessLayer/HostedService/AuthStartupTask.cs
+++ b/src/AutenticazioneSvc/AutenticazioneSvc.BusinessLayer/HostedService/AuthStartupTask.cs
@@ -1,4 +1,4 @@
-﻿using AutenticazioneSvc.DataAccessLayer.Entities;
+﻿using GSWCloudApp.Common.Identity.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/AutenticazioneSvc/AutenticazioneSvc.BusinessLayer/Services/IdentityService.cs
+++ b/src/AutenticazioneSvc/AutenticazioneSvc.BusinessLayer/Services/IdentityService.cs
@@ -2,10 +2,10 @@
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
-using AutenticazioneSvc.BusinessLayer.Extensions;
-using AutenticazioneSvc.BusinessLayer.Settings;
-using AutenticazioneSvc.DataAccessLayer.Entities;
 using AutenticazioneSvc.Shared.DTO;
+using GSWCloudApp.Common.Identity;
+using GSWCloudApp.Common.Identity.Entities;
+using GSWCloudApp.Common.Identity.Extensions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;

--- a/src/AutenticazioneSvc/AutenticazioneSvc.DataAccessLayer/AppDbContext.cs
+++ b/src/AutenticazioneSvc/AutenticazioneSvc.DataAccessLayer/AppDbContext.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using AutenticazioneSvc.DataAccessLayer.Entities;
+using GSWCloudApp.Common.Identity.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -9,10 +9,10 @@ namespace AutenticazioneSvc.DataAccessLayer;
 public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbContext<ApplicationUser, ApplicationRole, Guid,
     IdentityUserClaim<Guid>, ApplicationUserRole, IdentityUserLogin<Guid>, IdentityRoleClaim<Guid>, IdentityUserToken<Guid>>(options)
 {
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnModelCreating(ModelBuilder builder)
     {
-        base.OnModelCreating(modelBuilder);
+        base.OnModelCreating(builder);
 
-        modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+        builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
     }
 }

--- a/src/AutenticazioneSvc/AutenticazioneSvc.DataAccessLayer/Extension/ApplicationUserConfiguration.cs
+++ b/src/AutenticazioneSvc/AutenticazioneSvc.DataAccessLayer/Extension/ApplicationUserConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using AutenticazioneSvc.DataAccessLayer.Entities;
+﻿using GSWCloudApp.Common.Identity.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/AutenticazioneSvc/AutenticazioneSvc.DataAccessLayer/Extension/ApplicationUserRoleConfiguration.cs
+++ b/src/AutenticazioneSvc/AutenticazioneSvc.DataAccessLayer/Extension/ApplicationUserRoleConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using AutenticazioneSvc.DataAccessLayer.Entities;
+﻿using GSWCloudApp.Common.Identity.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/AutenticazioneSvc/AutenticazioneSvc.Shared/AutenticazioneSvc.Shared.csproj
+++ b/src/AutenticazioneSvc/AutenticazioneSvc.Shared/AutenticazioneSvc.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GSWCloudApp.Common" Version="1.0.41" />
+    <PackageReference Include="GSWCloudApp.Common" Version="1.0.42" />
   </ItemGroup>
 
 </Project>

--- a/src/AutenticazioneSvc/AutenticazioneSvc/AutenticazioneSvc.csproj
+++ b/src/AutenticazioneSvc/AutenticazioneSvc/AutenticazioneSvc.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <UserSecretsId>gswcloud_autenticazionesvc</UserSecretsId>
+    <UserSecretsId>gswcloud</UserSecretsId>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/AutenticazioneSvc/AutenticazioneSvc/appsettings.json
+++ b/src/AutenticazioneSvc/AutenticazioneSvc/appsettings.json
@@ -31,7 +31,7 @@
         "MountPoint": "secret"
     },
     "JwtOptions": {
-        "Issuer": "Modifica-Issuer",
+        "Issuer": "Italia",
         "Audience": "Gestione Sagre Web Cloud App",
         "SecurityKey": "stringa-512-caratteri",
         "AccessTokenExpirationMinutes": "60",


### PR DESCRIPTION
This pull request includes several changes to the `AutenticazioneSvc` project, primarily focused on updating namespaces, improving configuration, and simplifying the codebase. The most important changes include updating the namespace references to use `GSWCloudApp.Common.Identity`, modifying various configuration settings, and simplifying the `Program.cs` setup.

### Namespace Updates:
* Updated namespace references in `AuthStartupTask.cs`, `IdentityService.cs`, `AppDbContext.cs`, `ApplicationUserConfiguration.cs`, and `ApplicationUserRoleConfiguration.cs` to use `GSWCloudApp.Common.Identity` entities. [[1]](diffhunk://#diff-def26c19277cfd7d669d9ee60b99b886a91f82f3ac0e26ab1d5cd9c94aefffb1L1-R1) [[2]](diffhunk://#diff-ff76e8d876692a5eeab21af9204310982f694971e1dc7491c3734be9428382abL5-R8) [[3]](diffhunk://#diff-aa7de0c29fdf8b4b6781dd1a60a65494b6eda8e34fc0990b1f531b3d52529c31L2-R2) [[4]](diffhunk://#diff-9a65b8f8bf99614382c6433e2c98ac2f9c1fdd9108ad9dffb48f9b2035635ef2L1-R1) [[5]](diffhunk://#diff-c9d346ddb47b0fa8ae282d61a2483d3d50cd947b23bc0f011bc6f2937e9c781aL1-R1)

### Configuration Changes:
* Updated `GSWCloudApp.Common` package version from `1.0.41` to `1.0.42` in `AutenticazioneSvc.Shared.csproj`.
* Changed `UserSecretsId` in `AutenticazioneSvc.csproj` to a more generic value `gswcloud`.
* Modified `appsettings.json` to update the `Issuer` in `JwtOptions` from "Modifica-Issuer" to "Italia".

### Codebase Simplification:
* Simplified `Program.cs` by removing unnecessary using directives and configurations, such as `System.Text.Json.Serialization` and `UserActiveHandler`. Added `ConfigureJsonOptions` and replaced synchronous methods with their asynchronous counterparts. [[1]](diffhunk://#diff-427f1ddc65d8df514e2cc34630dbf3334e48cb372e0aff0983a224cb639f4212L2-L14) [[2]](diffhunk://#diff-427f1ddc65d8df514e2cc34630dbf3334e48cb372e0aff0983a224cb639f4212L28-R25) [[3]](diffhunk://#diff-427f1ddc65d8df514e2cc34630dbf3334e48cb372e0aff0983a224cb639f4212R65) [[4]](diffhunk://#diff-427f1ddc65d8df514e2cc34630dbf3334e48cb372e0aff0983a224cb639f4212L96-R93) [[5]](diffhunk://#diff-427f1ddc65d8df514e2cc34630dbf3334e48cb372e0aff0983a224cb639f4212L115-R102) [[6]](diffhunk://#diff-427f1ddc65d8df514e2cc34630dbf3334e48cb372e0aff0983a224cb639f4212L130-R117)

### Minor Refactor:
* Changed parameter names in `AppDbContext.cs` to use `builder` instead of `modelBuilder` for consistency.