### PR TITLE
Sync Main from Develop

### DIFF
--- a/src/AutenticazioneSvc/AutenticazioneSvc.Shared/AutenticazioneSvc.Shared.csproj
+++ b/src/AutenticazioneSvc/AutenticazioneSvc.Shared/AutenticazioneSvc.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GSWCloudApp.Common" Version="1.0.65" />
+    <PackageReference Include="GSWCloudApp.Common" Version="1.0.66" />
   </ItemGroup>
 
 </Project>

--- a/src/ConfigurazioniSvc/ConfigurazioniSvc.BusinessLayer/Mapper/MappingProfile.cs
+++ b/src/ConfigurazioniSvc/ConfigurazioniSvc.BusinessLayer/Mapper/MappingProfile.cs
@@ -4,14 +4,8 @@ using ConfigurazioniSvc.Shared.DTO;
 
 namespace ConfigurazioniSvc.BusinessLayer.Mapper;
 
-/// <summary>
-/// Defines the mapping profile for AutoMapper.
-/// </summary>
 public class MappingProfile : Profile
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MappingProfile"/> class.
-    /// </summary>
     public MappingProfile()
     {
 
@@ -20,12 +14,32 @@ public class MappingProfile : Profile
 
         CreateMap<Configurazione, EditConfigurazioneDto>();
         CreateMap<EditConfigurazioneDto, Configurazione>()
-            .ForMember(dst => dst.FestaId, opt => opt.PreCondition(src => src.FestaId != null))
-            .ForMember(dst => dst.Chiave, opt => opt.PreCondition(src => src.Chiave != null))
-            .ForMember(dst => dst.Valore, opt => opt.PreCondition(src => src.Valore != null))
-            .ForMember(dst => dst.Tipo, opt => opt.PreCondition(src => src.Tipo != null))
-            .ForMember(dst => dst.Posizione, opt => opt.PreCondition(src => src.Posizione != null))
-            .ForMember(dst => dst.Obbligatorio, opt => opt.PreCondition(src => src.Obbligatorio != null))
-            .ForMember(dst => dst.Scope, opt => opt.PreCondition(src => src.Scope != null));
+            .ForMember(dst => dst.FestaId, opt
+                => opt.PreCondition(src
+                    => src.FestaId != null))
+
+            .ForMember(dst => dst.Chiave, opt
+                => opt.PreCondition(src
+                    => src.Chiave != null))
+
+            .ForMember(dst => dst.Valore, opt
+                => opt.PreCondition(src
+                    => src.Valore != null))
+
+            .ForMember(dst => dst.Tipo, opt
+                => opt.PreCondition(src
+                    => src.Tipo != null))
+
+            .ForMember(dst => dst.Posizione, opt
+                => opt.PreCondition(src
+                    => src.Posizione != null))
+
+            .ForMember(dst => dst.Obbligatorio, opt
+                => opt.PreCondition(src
+                    => src.Obbligatorio != null))
+
+            .ForMember(dst => dst.Scope, opt
+                => opt.PreCondition(src
+                    => src.Scope != null));
     }
 }

--- a/src/ConfigurazioniSvc/ConfigurazioniSvc.BusinessLayer/Validation/ConfigurazioneValidator.cs
+++ b/src/ConfigurazioniSvc/ConfigurazioniSvc.BusinessLayer/Validation/ConfigurazioneValidator.cs
@@ -3,14 +3,8 @@ using FluentValidation;
 
 namespace ConfigurazioniSvc.BusinessLayer.Validation;
 
-/// <summary>
-/// Validator for creating configuration settings.
-/// </summary>
 public class CreateConfigurazioneValidator : AbstractValidator<CreateConfigurazioneDto>
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CreateConfigurazioneValidator"/> class.
-    /// </summary>
     public CreateConfigurazioneValidator()
     {
         RuleFor(x => x.FestaId)
@@ -35,16 +29,8 @@ public class CreateConfigurazioneValidator : AbstractValidator<CreateConfigurazi
     }
 }
 
-/// <summary>
-/// Validator for editing configuration settings.
-/// </summary>
 public class EditConfigurazioneValidator : AbstractValidator<EditConfigurazioneDto>
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EditConfigurazioneValidator"/> class.
-    /// </summary>
     public EditConfigurazioneValidator()
-    {
-        // Add validation rules here if needed
-    }
+    { }
 }

--- a/src/ConfigurazioniSvc/ConfigurazioniSvc.Shared/ConfigurazioniSvc.Shared.csproj
+++ b/src/ConfigurazioniSvc/ConfigurazioniSvc.Shared/ConfigurazioniSvc.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GSWCloudApp.Common" Version="1.0.65" />
+    <PackageReference Include="GSWCloudApp.Common" Version="1.0.66" />
     <PackageReference Include="Bogus" Version="35.6.1" />
   </ItemGroup>
 

--- a/src/ConfigurazioniSvc/ConfigurazioniSvc/ConfigurazioniSvc.csproj
+++ b/src/ConfigurazioniSvc/ConfigurazioniSvc/ConfigurazioniSvc.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <UserSecretsId>gswcloud_configurazionisvc</UserSecretsId>
+    <UserSecretsId>gswcloud</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ConfigurazioniSvc/ConfigurazioniSvc/Endpoints/ConfigurazioniEndpoints.cs
+++ b/src/ConfigurazioniSvc/ConfigurazioniSvc/Endpoints/ConfigurazioniEndpoints.cs
@@ -8,15 +8,8 @@ using Microsoft.OpenApi.Models;
 
 namespace ConfigurazioniSvc.Endpoints;
 
-/// <summary>  
-/// Defines the endpoints for the Configurazioni API.  
-/// </summary>  
 public class ConfigurazioniEndpoints : IEndpointRouteHandlerBuilder
 {
-    /// <summary>  
-    /// Maps the endpoints for the Configurazioni API.  
-    /// </summary>  
-    /// <param name="endpoints">The endpoint route builder.</param>  
     public static void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         var apiService = endpoints.ServiceProvider.GetRequiredService<IGenericService>();
@@ -29,9 +22,7 @@ public class ConfigurazioniEndpoints : IEndpointRouteHandlerBuilder
                 opt.Tags = [new OpenApiTag { Name = "Configurazioni" }];
 
                 return opt;
-            })
-        //.RequireAuthorization()  
-        ;
+            });
 
         apiGroup.MapGet(string.Empty, apiService.GetAllAsync<Configurazione, ConfigurazioneDto>)
             .Produces<List<ConfigurazioneDto>>(StatusCodes.Status200OK)
@@ -45,7 +36,7 @@ public class ConfigurazioniEndpoints : IEndpointRouteHandlerBuilder
                 return opt;
             });
 
-        apiGroup.MapGet(MinimalAPI.PatternById, apiService.GetByIdAsync<Configurazione, ConfigurazioneDto>)
+        apiGroup.MapGet(MinimalApi.PatternById, apiService.GetByIdAsync<Configurazione, ConfigurazioneDto>)
             .Produces<ConfigurazioneDto>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -71,7 +62,7 @@ public class ConfigurazioniEndpoints : IEndpointRouteHandlerBuilder
                 return opt;
             });
 
-        apiGroup.MapPatch(MinimalAPI.PatternById, apiService.UpdateAsync<Configurazione, ConfigurazioneDto, EditConfigurazioneDto>)
+        apiGroup.MapPatch(MinimalApi.PatternById, apiService.UpdateAsync<Configurazione, ConfigurazioneDto, EditConfigurazioneDto>)
             .Produces<ConfigurazioneDto>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -86,7 +77,7 @@ public class ConfigurazioniEndpoints : IEndpointRouteHandlerBuilder
                 return opt;
             });
 
-        apiGroup.MapDelete(MinimalAPI.PatternById, apiService.DeleteAsync<Configurazione>)
+        apiGroup.MapDelete(MinimalApi.PatternById, apiService.DeleteAsync<Configurazione>)
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -98,7 +89,7 @@ public class ConfigurazioniEndpoints : IEndpointRouteHandlerBuilder
                 return opt;
             });
 
-        apiGroup.MapGet(MinimalAPI.PatternFilterById, apiService.FilterByIdFestaAsync<Configurazione, ConfigurazioneDto>)
+        apiGroup.MapGet(MinimalApi.PatternFilterById, apiService.FilterByIdFestaAsync<Configurazione, ConfigurazioneDto>)
             .Produces<ConfigurazioneDto>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -108,7 +99,5 @@ public class ConfigurazioniEndpoints : IEndpointRouteHandlerBuilder
                 opt.Description = "Filter the configuration from the database with the given festaId";
                 return opt;
             });
-
-        //TODO: Manca una GET che genera i dati iniziali di configurazione, con un parametro in ingresso riferito all'Id festa  
     }
 }

--- a/src/ConfigurazioniSvc/ConfigurazioniSvc/appsettings.json
+++ b/src/ConfigurazioniSvc/ConfigurazioniSvc/appsettings.json
@@ -1,9 +1,37 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
-        }
+    "Serilog": {
+        "MinimumLevel": "Information",
+        "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "outputTemplate": "{Timestamp:HH:mm:ss}\t{Level:u3}\t{SourceContext}\t{Message}{NewLine}{Exception}"
+                }
+            },
+            {
+                "Name": "File",
+                "Args": {
+                    "path": "Logs/log.txt",
+                    "rollingInterval": "Day",
+                    "retainedFileCountLimit": 15,
+                    "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog"
+                }
+            },
+            {
+                "Name": "MongoDB",
+                "Args": {
+                    "databaseUrl": "mongodb://[USERNAME]:[PASSWORD]@[HOSTNAME]:27017/gswcloudapp?authSource=admin",
+                    "collectionName": "configurazionisvc",
+                    "cappedMaxSizeMb": "1024",
+                    "cappedMaxDocuments": "10000",
+                    "restrictedToMinimumLevel": "Warning",
+                    "rollingInterval": "Day",
+                    "retentionDays": "30",
+                    "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog"
+                }
+            }
+        ]
     },
     "Kestrel": {
         "Limits": {
@@ -11,7 +39,7 @@
         }
     },
     "ConnectionStrings": {
-        "SqlConnection": "Host=[HOSTNAME];Port=[PORT];Database=gswcloud_configurazioni;Username=[USERNAME];Password=[PASSWORD];Include Error Detail=true"
+        "SqlConfigurazioni": "Host=[HOSTNAME];Port=[PORT];Database=configurazionisvc;Username=[USERNAME];Password=[PASSWORD];Include Error Detail=true"
     },
     "ApplicationOptions": {
         "TabellaMigrazioni": "StoricoMigrazioni",
@@ -21,14 +49,9 @@
     },
     "RedisOptions": {
         "Hostname": "localhost:6379",
-        "InstanceName": "ConfigurazioneSvc",
+        "InstanceName": "ConfigurazioniSvc",
         "AbsoluteExpireTime": "01:00:00",
         "SlidingExpireTime": "00:15:00"
-    },
-    "VaultOptions": {
-        "Address": "http://my-vault-address:8200",
-        "Token": "my-vault-token",
-        "MountPoint": "secret"
     },
     "AllowedHosts": "*"
 }

--- a/src/GatewaySvc/GatewaySvc/GatewaySvc.csproj
+++ b/src/GatewaySvc/GatewaySvc/GatewaySvc.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GSWCloudApp.Common" Version="1.0.65" />
+    <PackageReference Include="GSWCloudApp.Common" Version="1.0.66" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="Ocelot" Version="23.4.2" />
   </ItemGroup>


### PR DESCRIPTION
This pull request includes updates across several projects, mainly focusing on updating package versions, improving code formatting, and enhancing logging configurations. The most important changes include updating the `GSWCloudApp.Common` package version, reformatting mapping profiles and validators, and introducing Serilog for logging.

Package Updates:
* Updated `GSWCloudApp.Common` package version from `1.0.65` to `1.0.66` in `AutenticazioneSvc`, `ConfigurazioniSvc`, and `GatewaySvc` projects. [[1]](diffhunk://#diff-8f3df750001ef26cb23098afe6daac9a1ef4cde992bd17cb8e90cdab5edd3cd8L10-R10) [[2]](diffhunk://#diff-2c8d55b3bd1ea2ebcca561c21fc0e4d94b175a960653dc7caf4a7664a723de07L10-R10) [[3]](diffhunk://#diff-d59b038d30bd30dfb37c14bb439d4c47e74e35a6fbfb7bdfa0a022eadecc6467L11-R11)

Code Formatting:
* Reformatted `MappingProfile` class to improve readability by adjusting the `ForMember` method calls.
* Removed XML documentation comments from `MappingProfile` and `ConfigurazioneValidator` classes to clean up the code. [[1]](diffhunk://#diff-953437a9f254fca59672b1bb4df860863337ab4d8624ee2e6a4d15ee2cec5753L7-L14) [[2]](diffhunk://#diff-18cdaf0b434b6ae57cff2b600ef2dd813252589f60c0d7b71fc181080acad2ceL6-L13) [[3]](diffhunk://#diff-18cdaf0b434b6ae57cff2b600ef2dd813252589f60c0d7b71fc181080acad2ceL38-R35)

Logging Enhancements:
* Introduced Serilog for enhanced logging capabilities in the `ConfigurazioniSvc` project, with configurations added to `Program.cs` and `appsettings.json`. [[1]](diffhunk://#diff-b493494a8dbbe2d1712ce76f22113ad0bc3edeacb8b7f4544440d128428109a9L1-R44) [[2]](diffhunk://#diff-1bf7c80d4d35e4cb547ec79975969f02d95752190d1d466bd0d8309b2497db74L2-R42) [[3]](diffhunk://#diff-1bf7c80d4d35e4cb547ec79975969f02d95752190d1d466bd0d8309b2497db74L24-L32)

Other Changes:
* Corrected `UserSecretsId` in `ConfigurazioniSvc.csproj` to ensure proper configuration management.
* Fixed typos and improved method calls in `ConfigurazioniEndpoints.cs` for better API endpoint handling. [[1]](diffhunk://#diff-d35ebd5ceeb6192e9a2852a89841fb34fd188cfc38069fd6c87120f5f202c12fL32-R25) [[2]](diffhunk://#diff-d35ebd5ceeb6192e9a2852a89841fb34fd188cfc38069fd6c87120f5f202c12fL48-R39) [[3]](diffhunk://#diff-d35ebd5ceeb6192e9a2852a89841fb34fd188cfc38069fd6c87120f5f202c12fL74-R65) [[4]](diffhunk://#diff-d35ebd5ceeb6192e9a2852a89841fb34fd188cfc38069fd6c87120f5f202c12fL89-R80) [[5]](diffhunk://#diff-d35ebd5ceeb6192e9a2852a89841fb34fd188cfc38069fd6c87120f5f202c12fL101-R92) [[6]](diffhunk://#diff-d35ebd5ceeb6192e9a2852a89841fb34fd188cfc38069fd6c87120f5f202c12fL111-L112)