### PR TITLE
Update publish-autenticazionesvc-lb.yml

### DIFF
--- a/.github/workflows/publish-autenticazionesvc-lb.yml
+++ b/.github/workflows/publish-autenticazionesvc-lb.yml
@@ -31,4 +31,4 @@ jobs:
          context: .
          file: ./src/AutenticazioneSvc/AutenticazioneSvc.LoadBalancer/Dockerfile
          push: true
-         tags: ${{ secrets.DOCKER_USERNAME }}/gswcloudapp-autenticazione-lb:latest
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-autenticazione-lb:latest


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/publish-autenticazionesvc-lb.yml` file. The change updates the Docker image tag to use a new naming convention.

* [`.github/workflows/publish-autenticazionesvc-lb.yml`](diffhunk://#diff-997b66fd7097b447b7b963d74893a27105ed1b5dc7b39d475c0b21bc89936148L34-R34): Changed the Docker image tag from `gswcloudapp-autenticazione-lb:latest` to `gswca-autenticazione-lb:latest`.