### PR TITLE
Update publish-configurazionisvc-lb.yml

### DIFF
--- a/.github/workflows/publish-configurazionisvc-lb.yml
+++ b/.github/workflows/publish-configurazionisvc-lb.yml
@@ -31,4 +31,4 @@ jobs:
          context: .
          file: ./src/ConfigurazioniSvc/ConfigurazioniSvc.LoadBalancer/Dockerfile
          push: true
-         tags: ${{ secrets.DOCKER_USERNAME }}/gswcloudapp-configurazioni-lb:latest
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-configurazioni-lb:latest


### PR DESCRIPTION
This pull request includes a small but important change to the Docker image tagging in the `publish-configurazionisvc-lb.yml` file. The change updates the Docker image tag to use a new repository name.

* [`.github/workflows/publish-configurazionisvc-lb.yml`](diffhunk://#diff-c18720015e0cf4d1a7d0b442a6418af42b4438283f17c5ccdd77a9e352663b12L34-R34): Changed the Docker image tag from `gswcloudapp-configurazioni-lb:latest` to `gswca-configurazioni-lb:latest`.