### PR TITLE
Update publish-gestionedocumentisvc.yml

### DIFF
--- a/.github/workflows/publish-gestionedocumentisvc.yml
+++ b/.github/workflows/publish-gestionedocumentisvc.yml
@@ -35,4 +35,4 @@ jobs:
          context: .
          file: ./src/GestioneDocumentiSvc/GestioneDocumentiSvc/Dockerfile
          push: true
-         tags: ${{ secrets.DOCKER_USERNAME }}/gswcloudapp-gestionedocumenti:latest
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-gestionedocumenti:latest


### PR DESCRIPTION
This pull request includes a change to the Docker image tag in the `publish-gestionedocumentisvc.yml` workflow file. The tag has been updated to reflect a new naming convention.

* [`.github/workflows/publish-gestionedocumentisvc.yml`](diffhunk://#diff-4c49cd97107cbbdf07f9f2df3f2ee440bf3da179fb1725deb614f511a88b0401L38-R38): Updated the Docker image tag from `gswcloudapp-gestionedocumenti:latest` to `gswca-gestionedocumenti:latest`.