### PR TITLE
Update publish-gestionedocumentisvc-lb.yml

### DIFF
--- a/.github/workflows/publish-gestionedocumentisvc-lb.yml
+++ b/.github/workflows/publish-gestionedocumentisvc-lb.yml
@@ -31,4 +31,4 @@ jobs:
          context: .
          file: ./src/GestioneDocumentiSvc/GestioneDocumentiSvc.LoadBalancer/Dockerfile
          push: true
-         tags: ${{ secrets.DOCKER_USERNAME }}/gswcloudapp-gestionedocumenti-lb:latest
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-gestionedocumenti-lb:latest


### PR DESCRIPTION
This pull request includes a change to the Docker image tag in the `publish-gestionedocumentisvc-lb.yml` workflow file. The most important change is:

* [`.github/workflows/publish-gestionedocumentisvc-lb.yml`](diffhunk://#diff-d3321481394d30ea337b132bc01e3d2f69f303f3693f807f9a137ef18e50968cL34-R34): Updated the Docker image tag from `gswcloudapp-gestionedocumenti-lb:latest` to `gswca-gestionedocumenti-lb:latest`.