### PR TITLE
Create publish-tiposcontrinosvc.yml

### DIFF
--- a/.github/workflows/publish-tiposcontrinosvc.yml
+++ b/.github/workflows/publish-tiposcontrinosvc.yml
@@ -1,0 +1,38 @@
+name: Push TipoScontrinoSvc to DockerHub
+
+on:
+  push:
+    branches: [ main ]
+    paths: 
+       - 'src/TipoScontrinoSvc/TipoScontrinoSvc/**'
+       - 'src/TipoScontrinoSvc/TipoScontrinoSvc.BusinessLayer/**'
+       - 'src/TipoScontrinoSvc/TipoScontrinoSvc.DataAccessLayer/**'
+       - 'src/TipoScontrinoSvc/TipoScontrinoSvc.Migrations/**'
+       - 'src/TipoScontrinoSvc/TipoScontrinoSvc.Shared/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Push images to DockerHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.7.1
+
+      - name: Build and push Gestione Documenti
+        uses: docker/build-push-action@v6.9.0
+        with:
+         context: .
+         file: ./src/TipoScontrinoSvc/TipoScontrinoSvc/Dockerfile
+         push: true
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-tiposcontrino:latest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of pushing the `TipoScontrinoSvc` service to DockerHub. The most important changes include the creation of the workflow file and the configuration of steps to build and push the Docker image.

New GitHub Actions workflow:

* [`.github/workflows/publish-tiposcontrinosvc.yml`](diffhunk://#diff-187d99e2fe61804cedbed8d1cfbc2f96755d63274f22e4bb7ebbaa6a589d3ab9R1-R38): Added a new workflow named "Push TipoScontrinoSvc to DockerHub" that triggers on pushes to the main branch and specific paths, and includes steps for checking out the repository, logging in to Docker Hub, setting up Docker Buildx, and building and pushing the Docker image.