### PR TITLE
Create publish-gestioneloghisvc.yml

### DIFF
--- a/.github/workflows/publish-gestioneloghisvc.yml
+++ b/.github/workflows/publish-gestioneloghisvc.yml
@@ -1,0 +1,38 @@
+name: Push GestioneLoghiSvc to DockerHub
+
+on:
+  push:
+    branches: [ main ]
+    paths: 
+       - 'src/GestioneLoghiSvc/GestioneLoghiSvc/**'
+       - 'src/GestioneLoghiSvc/GestioneLoghiSvc.BusinessLayer/**'
+       - 'src/GestioneLoghiSvc/GestioneLoghiSvc.DataAccessLayer/**'
+       - 'src/GestioneLoghiSvc/GestioneLoghiSvc.Migrations/**'
+       - 'src/GestioneLoghiSvc/GestioneLoghiSvc.Shared/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Push images to DockerHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.7.1
+
+      - name: Build and push Gestione Documenti
+        uses: docker/build-push-action@v6.9.0
+        with:
+         context: .
+         file: ./src/GestioneLoghiSvc/GestioneLoghiSvc/Dockerfile
+         push: true
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-gestioneloghi:latest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of pushing the `GestioneLoghiSvc` service to DockerHub. The key changes include setting up the workflow to trigger on specific branches and paths, and configuring the necessary steps to build and push the Docker image.

New GitHub Actions workflow:

* [`.github/workflows/publish-gestioneloghisvc.yml`](diffhunk://#diff-8cf5bc2463956a128b63a6c7ce294b60b169fb9849c204917cd7093a610db302R1-R38): Added a new workflow named "Push GestioneLoghiSvc to DockerHub" that triggers on pushes to the main branch and specific paths. It includes steps for checking out the repository, logging into Docker Hub, setting up Docker Buildx, and building and pushing the Docker image.