### PR TITLE
Create publish-tiposcontrinosvc-lb.yml

### DIFF
--- a/.github/workflows/publish-tiposcontrinosvc-lb.yml
+++ b/.github/workflows/publish-tiposcontrinosvc-lb.yml
@@ -1,0 +1,34 @@
+name: Push TipoScontrinoSvc LB to DockerHub
+
+on:
+  push:
+    branches: [ main ]
+    paths: 
+       - 'src/TipoScontrinoSvc/TipoScontrinoSvc.LoadBalancer/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Push images to DockerHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.7.1
+
+      - name: Build and push Tipo Scontrino Load Balancer
+        uses: docker/build-push-action@v6.9.0
+        with:
+         context: .
+         file: ./src/TipoScontrinoSvc/TipoScontrinoSvc.LoadBalancer/Dockerfile
+         push: true
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-tiposcontrino-lb:latest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of pushing the TipoScontrinoSvc Load Balancer to DockerHub. The most important changes include the addition of the workflow configuration file and the steps necessary for building and pushing the Docker image.

New GitHub Actions workflow:

* [`.github/workflows/publish-tiposcontrinosvc-lb.yml`](diffhunk://#diff-a529c138b16c99e6228895647883d66a4b462a2ce199770699ab8c9d779dcfd6R1-R34): Added a new workflow to push the TipoScontrinoSvc Load Balancer to DockerHub on each push to the `main` branch or when manually triggered. This workflow includes steps for checking out the code, logging into Docker Hub, setting up Docker Buildx, and building and pushing the Docker image.