### PR TITLE
Create publish-gestioneloghisvc-lb.yml

### DIFF
--- a/.github/workflows/publish-gestioneloghisvc-lb.yml
+++ b/.github/workflows/publish-gestioneloghisvc-lb.yml
@@ -1,0 +1,34 @@
+name: Push GestioneLoghiSvc LB to DockerHub
+
+on:
+  push:
+    branches: [ main ]
+    paths: 
+       - 'src/GestioneLoghiSvc/GestioneLoghiSvc.LoadBalancer/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Push images to DockerHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.7.1
+
+      - name: Build and push Gestione Loghi Load Balancer
+        uses: docker/build-push-action@v6.9.0
+        with:
+         context: .
+         file: ./src/GestioneLoghiSvc/GestioneLoghiSvc.LoadBalancer/Dockerfile
+         push: true
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-gestioneloghi-lb:latest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of pushing the Gestione Loghi Load Balancer service to DockerHub.

New GitHub Actions workflow:

* [`.github/workflows/publish-gestioneloghisvc-lb.yml`](diffhunk://#diff-b11c1f0e4891a8e1ca6095f91150b2339330ddaef1a07150eb5aec643efe7d09R1-R34): Added a workflow that triggers on pushes to the `main` branch and specific paths, and includes steps for checking out the repository, logging into Docker Hub, setting up Docker Buildx, and building and pushing the Docker image.