### PR TITLE
Update build-pack-common.yml

### DIFF
--- a/.github/workflows/build-pack-common.yml
+++ b/.github/workflows/build-pack-common.yml
@@ -1,9 +1,9 @@
 name: Build and Pack Common
 
 on:
-  push:
-    branches: [ main ]
-    paths: [ 'src/GSWCloudApp.Common/**' ]
+  #push:
+    #branches: [ main ]
+    #paths: [ 'src/GSWCloudApp.Common/**' ]
   workflow_dispatch:
       
 env:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/build-pack-common.yml` file. The change comments out the push event trigger, which previously triggered the workflow on pushes to the main branch for paths under `src/GSWCloudApp.Common`.

Changes to workflow triggers:

* [`.github/workflows/build-pack-common.yml`](diffhunk://#diff-3956a282f7eed8fcca465b4caa569e8b93f28b3e77681e140bdf4059059b4924L4-R6): Commented out the push event trigger for the workflow, which previously ran on pushes to the main branch for paths under `src/GSWCloudApp.Common`.