### PR TITLE
Create publish-traduzioniSvc.yml

### DIFF
--- a/.github/workflows/publish-traduzioniSvc.yml
+++ b/.github/workflows/publish-traduzioniSvc.yml
@@ -1,0 +1,38 @@
+name: Push TraduzioniSvc to DockerHub
+
+on:
+  push:
+    branches: [ main ]
+    paths: 
+       - 'src/TraduzioniSvc/TraduzioniSvc/**'
+       - 'src/TraduzioniSvc/TraduzioniSvc.BusinessLayer/**'
+#       - 'src/TraduzioniSvc/TraduzioniSvc.DataAccessLayer/**'
+#       - 'src/TraduzioniSvc/TraduzioniSvc.Migrations/**'
+       - 'src/TraduzioniSvc/TraduzioniSvc.Shared/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Push images to DockerHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.7.1
+
+      - name: Build and push Traduzioni
+        uses: docker/build-push-action@v6.9.0
+        with:
+         context: .
+         file: ./src/TraduzioniSvc/TraduzioniSvc/Dockerfile
+         push: true
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-traduzionisvc:latest


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the process of pushing the `TraduzioniSvc` service to DockerHub. The workflow is triggered on pushes to the `main` branch and includes specific paths related to the `TraduzioniSvc` service.

New GitHub Actions workflow:

* [`.github/workflows/publish-traduzioniSvc.yml`](diffhunk://#diff-ac07fd565c0db7054499c96bb98ead149e62ac1baec85fbf3af466af47202e5bR1-R38): Added a new workflow named "Push TraduzioniSvc to DockerHub" that triggers on pushes to the `main` branch and specified paths. It includes steps for checking out the repository, logging into Docker Hub, setting up Docker Buildx, and building and pushing the Docker image for `TraduzioniSvc`.