### PR TITLE
Update publish-configurazionesmtpsvc-lb.yml

### DIFF
--- a/.github/workflows/publish-configurazionesmtpsvc-lb.yml
+++ b/.github/workflows/publish-configurazionesmtpsvc-lb.yml
@@ -31,4 +31,4 @@ jobs:
          context: .
          file: ./src/ConfigurazioneSmtpSvc/ConfigurazioneSmtpSvc.LoadBalancer/Dockerfile
          push: true
-         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-configurazionesmtpsvc-lb:latest
+         tags: ${{ secrets.DOCKER_USERNAME }}/gswca-configurazionesmtp-lb:latest


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/publish-configurazionesmtpsvc-lb.yml` file. The change corrects the Docker image tag to ensure it matches the intended repository name.

* [`.github/workflows/publish-configurazionesmtpsvc-lb.yml`](diffhunk://#diff-bfe43b092fa7c979eb9774460d8c93b27bfd7404dc22699727d9f9d88f5abf27L34-R34): Updated the Docker image tag from `gswca-configurazionesmtpsvc-lb:latest` to `gswca-configurazionesmtpsvc-lb:latest`.