### PR TITLE
Update publish-invioemailsvc.yml

### DIFF
--- a/.github/workflows/publish-invioemailsvc.yml
+++ b/.github/workflows/publish-invioemailsvc.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.7.1
 
-      - name: Build and push configurazioni Smtp
+      - name: Build and push Invio Email
         uses: docker/build-push-action@v6.9.0
         with:
          context: .


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/publish-invioemailsvc.yml` file. The change updates the name of a Docker build and push job to reflect the new service name.

* [`.github/workflows/publish-invioemailsvc.yml`](diffhunk://#diff-d9644587670b31f4c03b10cef489adaa78f55f05c34dacdaab6e0f776cfa74d9L32-R32): Changed job name from "Build and push configurazioni Smtp" to "Build and push Invio Email".